### PR TITLE
ライン座標チェックのアサーション範囲の修正

### DIFF
--- a/server/nlcheck.py
+++ b/server/nlcheck.py
@@ -199,8 +199,8 @@ class NLCheck:
                     y = int(y)
                     z = int(z)
                     size_x, size_y, layer_num = size
-                    assert(1 <= x <= size_x)
-                    assert(1 <= y <= size_y)
+                    assert(0 <= x < size_x)
+                    assert(0 <= y < size_y)
                     assert(1 <= z <= layer_num)
                     line_mat[num-1, positer*3+0] = x
                     line_mat[num-1, positer*3+1] = y


### PR DESCRIPTION
早稲田大学の寺田です。お世話になっています。

ラインの座標チェックのassert文の範囲が間違っていると思われますので修正しました。
サンプル問題をみる限り、問題ファイル内でのラインのX, Y座標の範囲は「0 ~ (盤面XorYサイズ - 1)」すなわち0オリジンと認識しております。`server/nlcheck.py` 内の座標チェックのアサーションが1オリジンとなっていてずれが生じているため、ラインのX, Y座標が0である問題ファイルを入力するとアサーションエラーとなってしまいます。

アサーション部分を修正したものをpull requestしますので、問題なければマージしていただければ幸いです。
以上、よろしくお願いします。
